### PR TITLE
Add a simple CuPy transpose addition benchmark

### DIFF
--- a/cupy-transpose.ipynb
+++ b/cupy-transpose.ipynb
@@ -51,9 +51,14 @@
     "import dask\n",
     "import dask.array\n",
     "import cupy\n",
+    "import numpy\n",
     "\n",
     "\n",
+    "# CPU\n",
+    "#rs = dask.array.random.RandomState(RandomState=numpy.random.RandomState)\n",
+    "# GPU\n",
     "rs = dask.array.random.RandomState(RandomState=cupy.random.RandomState)\n",
+    "\n",
     "a = rs.random((10000, 10000), chunks=100)\n",
     "a = a.persist()"
    ]

--- a/cupy-transpose.ipynb
+++ b/cupy-transpose.ipynb
@@ -1,0 +1,190 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Adding transposed arrays with Dask and CuPy\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use a DGX"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dask\n",
+    "import dask.config\n",
+    "\n",
+    "from dask.distributed import Client, wait\n",
+    "from dask_cuda import LocalCUDACluster\n",
+    "\n",
+    "dask.config.set({\"distributed.dashboard.link\": \"/proxy/8787/status\"})\n",
+    "cluster = LocalCUDACluster(diagnostics_port=9100)\n",
+    "client = Client(cluster)\n",
+    "client"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create Random Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dask\n",
+    "import dask.array\n",
+    "import cupy\n",
+    "\n",
+    "\n",
+    "a = dask.array.random.random((1000, 1000), chunks=100)\n",
+    "a = a.persist()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Convert data to GPU and persist in device memory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dask\n",
+    "import cupy\n",
+    "\n",
+    "ga = a.map_blocks(cupy.asarray)\n",
+    "ga = ga.persist()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Add array with its transpose\n",
+    "\n",
+    "This takes an array and adds it to its transpose. This involves some computations that have dependencies and some that don't."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "out = ga + ga.T"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "start = time.time()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "out = out.persist()\n",
+    "%time _ = wait(out)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "out.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_ = client.profile(start=start, filename='dask-cupy-add-transpose.html')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Inspect output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "out[:10, :10].compute()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from distributed.utils import format_bytes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "format_bytes(out.nbytes)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/cupy-transpose.ipynb
+++ b/cupy-transpose.ipynb
@@ -36,7 +36,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Create Random Dataset"
+    "## Create Random Dataset\n",
+    "\n",
+    "This is done on GPU."
    ]
   },
   {
@@ -50,7 +52,8 @@
     "import cupy\n",
     "\n",
     "\n",
-    "a = dask.array.random.random((1000, 1000), chunks=100)\n",
+    "rs = dask.array.random.RandomState(RandomState=cupy.random.RandomState)\n",
+    "a = rs.random((10000, 10000), chunks=100)\n",
     "a = a.persist()"
    ]
   },

--- a/cupy-transpose.ipynb
+++ b/cupy-transpose.ipynb
@@ -72,7 +72,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "out = ga + ga.T"
+    "out = a + a.T"
    ]
   },
   {

--- a/cupy-transpose.ipynb
+++ b/cupy-transpose.ipynb
@@ -5,7 +5,8 @@
    "metadata": {},
    "source": [
     "# Adding transposed arrays with Dask and CuPy\n",
-    "\n"
+    "\n",
+    "This is a communication heavy computation on GPUs. Currently this will be slow as there is not good UCX support. Though we would hope this improves in the future."
    ]
   },
   {

--- a/cupy-transpose.ipynb
+++ b/cupy-transpose.ipynb
@@ -61,26 +61,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Convert data to GPU and persist in device memory"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import dask\n",
-    "import cupy\n",
-    "\n",
-    "ga = a.map_blocks(cupy.asarray)\n",
-    "ga = ga.persist()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Add array with its transpose\n",
     "\n",
     "This takes an array and adds it to its transpose. This involves some computations that have dependencies and some that don't."

--- a/cupy-transpose.ipynb
+++ b/cupy-transpose.ipynb
@@ -27,7 +27,6 @@
     "from dask.distributed import Client, wait\n",
     "from dask_cuda import LocalCUDACluster\n",
     "\n",
-    "dask.config.set({\"distributed.dashboard.link\": \"/proxy/8787/status\"})\n",
     "cluster = LocalCUDACluster(diagnostics_port=9100)\n",
     "client = Client(cluster)\n",
     "client"


### PR DESCRIPTION
Provides a benchmark leveraging CuPy to compute adding a matrix to its transpose with Dask.